### PR TITLE
Add release to be able to use tagged references with rebar

### DIFF
--- a/src/dynarec.app.src
+++ b/src/dynarec.app.src
@@ -1,7 +1,7 @@
 {application, dynarec,
  [
   {description, "Parse transform for records"},
-  {vsn, "1"},
+  {vsn, "0.1.0"},
   {registered, []},
   {applications, [
                   kernel,


### PR DESCRIPTION
Set the version number to 0.1.0 and tagged the release.
